### PR TITLE
Ktr dtb

### DIFF
--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -66,19 +66,14 @@ int main(int argc, char *argv[])
 		wait_any_key_poweroff();
 	}
 
-	if (!load_file(FALLBACK_PATH LINUXIMAGE_FILENAME, ZIMAGE_ADDR)) {
-		if (!load_file(LINUXIMAGE_FILENAME, ZIMAGE_ADDR))
-			goto error;
-	}
+	if (!load_file(LINUXIMAGE_FILENAME, ZIMAGE_ADDR))
+		goto error;
 
-	if (!load_file(FALLBACK_PATH DTB_FILENAME, PARAMS_ADDR)) {
-		if (!load_file(DTB_FILENAME, PARAMS_ADDR))
-			goto error;
-	}
+	if (!load_file(CTR_DTB_FILENAME, PARAMS_ADDR))
+		goto error;
 
-	if (!load_file(FALLBACK_PATH ARM9LINUXFW_FILENAME, ARM9LINUXFW_ADDR)) {
-		if (!load_file(ARM9LINUXFW_FILENAME, ARM9LINUXFW_ADDR))
-			Debug("Continuing without an arm9linuxfw...");
+	if (!load_file(ARM9LINUXFW_FILENAME, ARM9LINUXFW_ADDR)) {
+		Debug("Continuing without an arm9linuxfw...");
 	} else {
 		has_arm9linuxfw = 1;
 	}

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -49,8 +49,14 @@ static int load_file(const char *filename, uint32_t addr)
 	return 1;
 }
 
+static bool isKtr(void)
+{
+	return (*(int*)SOCINFO & 2) != 0;
+}
+
 int main(int argc, char *argv[])
 {
+	const char* dtb_filename;
 	int has_arm9linuxfw = 0;
 
 	InitScreenFbs(argc, argv);
@@ -66,11 +72,16 @@ int main(int argc, char *argv[])
 		wait_any_key_poweroff();
 	}
 
-	if (!load_file(LINUXIMAGE_FILENAME, ZIMAGE_ADDR))
+	if (!load_file(LINUXIMAGE_FILENAME, ZIMAGE_ADDR)) {
+		Debug("Failed to load " LINUXIMAGE_FILENAME);
 		goto error;
+	}
 
-	if (!load_file(CTR_DTB_FILENAME, PARAMS_ADDR))
+	dtb_filename = isKtr() ? KTR_DTB_FILENAME : CTR_DTB_FILENAME;
+	if (!load_file(dtb_filename, PARAMS_ADDR)) {
+		Debug("Failed to load %s", dtb_filename);
 		goto error;
+	}
 
 	if (!load_file(ARM9LINUXFW_FILENAME, ARM9LINUXFW_ADDR)) {
 		Debug("Continuing without an arm9linuxfw...");

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -49,14 +49,14 @@ static int load_file(const char *filename, uint32_t addr)
 	return 1;
 }
 
-static bool isKtr(void)
+static bool is_ktr(void)
 {
 	return (*(int*)SOCINFO & 2) != 0;
 }
 
 int main(int argc, char *argv[])
 {
-	const char* dtb_filename;
+	const char *dtb_filename;
 	int has_arm9linuxfw = 0;
 
 	InitScreenFbs(argc, argv);
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
 		goto error;
 	}
 
-	dtb_filename = isKtr() ? KTR_DTB_FILENAME : CTR_DTB_FILENAME;
+	dtb_filename = is_ktr() ? KTR_DTB_FILENAME : CTR_DTB_FILENAME;
 	if (!load_file(dtb_filename, PARAMS_ADDR)) {
 		Debug("Failed to load %s", dtb_filename);
 		goto error;

--- a/common/linux_config.h
+++ b/common/linux_config.h
@@ -5,10 +5,12 @@
 #define INITRD_ADDR      (0x20000000)
 #define MACHINE_NUMBER   (0xFFFFFFFF)
 #define ARM9LINUXFW_ADDR (0x08080000)
+#define SOCINFO          (0x10140FFC)
 #define SYNC_ADDR        (0x1FFFFFF8)
 
 #define LINUXIMAGE_FILENAME  "linux/zImage"
-#define DTB_FILENAME         "linux/nintendo3ds_ctr.dtb"
+#define CTR_DTB_FILENAME     "linux/nintendo3ds_ctr.dtb"
+#define KTR_DTB_FILENAME     "linux/nintendo3ds_ktr.dtb"
 #define ARM9LINUXFW_FILENAME "linux/arm9linuxfw.bin"
 
 /* 3DS memory layout */

--- a/common/linux_config.h
+++ b/common/linux_config.h
@@ -7,11 +7,9 @@
 #define ARM9LINUXFW_ADDR (0x08080000)
 #define SYNC_ADDR        (0x1FFFFFF8)
 
-#define LINUXIMAGE_FILENAME  "/zImage"
-#define DTB_FILENAME         "/nintendo3ds_ctr.dtb"
-#define ARM9LINUXFW_FILENAME "/arm9linuxfw.bin"
-
-#define FALLBACK_PATH        "/linux"
+#define LINUXIMAGE_FILENAME  "linux/zImage"
+#define DTB_FILENAME         "linux/nintendo3ds_ctr.dtb"
+#define ARM9LINUXFW_FILENAME "linux/arm9linuxfw.bin"
 
 /* 3DS memory layout */
 #define VRAM_BASE     (0x18000000)


### PR DESCRIPTION
I also made it required for zImage and dtbs to be in linux/.  I kind of want to make arm9linuxfw required to be in there, too.

Probably should wait though to merge this until after we have a working nintendo3ds_ktr.dtb; https://github.com/linux-3ds/linux/pull/14 doesn't quite yet boot for me.  I'm not sure if it's claiming there's 4 cpus when 1-3 aren't initialized or if the dtb is somehow bad.  Posting this anyways for feedback.