### PR TITLE
Remove devkit arm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,3 @@
-ifeq ($(strip $(DEVKITARM)),)
-$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
-endif
-
-include $(DEVKITARM)/base_tools
-
 TARGET		= firm_linux_loader
 ARM9_ELF	= arm9/firm_linux_loader_arm9.elf
 ARM11_ELF	= arm11/firm_linux_loader_arm11.elf

--- a/arm11/Makefile
+++ b/arm11/Makefile
@@ -1,9 +1,3 @@
-ifeq ($(strip $(DEVKITARM)),)
-$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
-endif
-
-include $(DEVKITARM)/base_tools
-
 TARGET		= firm_linux_loader_arm11
 SOURCES		= source source/fatfs
 INCLUDES	= include include/fatfs ../common
@@ -17,14 +11,14 @@ INCLUDE	= $(foreach dir, $(INCLUDES), -I$(CURDIR)/$(dir)) -Iinclude_common
 
 ARCH	= -mcpu=mpcore -march=armv6k -mlittle-endian -mthumb-interwork
 ASFLAGS	= $(ARCH) $(COMMON_ARCH) $(INCLUDE) -x assembler-with-cpp
-CFLAGS	= -Wall -O0 -fno-builtin -nostartfiles $(ARCH) $(INCLUDE)
+CFLAGS	= -Wall -Os -fno-builtin $(ARCH) $(INCLUDE) -fno-stack-protector
 
 .PHONY: all clean copy
 
 all: $(TARGET).elf
 
 $(TARGET).elf: $(OBJS)
-	$(CC) -T link.ld -Wl,--nmagic $^ -o $@
+	$(CC) -T link.ld -Wl,--nmagic $^ -o $@ -nostartfiles
 %.o: %.c
 	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 %.o: %.s

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -1,9 +1,3 @@
-ifeq ($(strip $(DEVKITARM)),)
-$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
-endif
-
-include $(DEVKITARM)/base_tools
-
 TARGET		= firm_linux_loader_arm9
 SOURCES		= source source/fatfs
 INCLUDES	= include include/fatfs ../common
@@ -17,14 +11,14 @@ INCLUDE	= $(foreach dir, $(INCLUDES), -I$(CURDIR)/$(dir)) -Iinclude_common
 
 ARCH	= -mcpu=arm946e-s -march=armv5te -mlittle-endian -mthumb-interwork
 ASFLAGS	= $(ARCH) $(COMMON_ARCH) $(INCLUDE) -x assembler-with-cpp
-CFLAGS	= -Wall -O0 -fno-builtin -nostartfiles $(ARCH) $(INCLUDE)
+CFLAGS	= -Wall -Os -fno-builtin $(ARCH) $(INCLUDE) -fno-stack-protector
 
 .PHONY: all clean copy
 
 all: $(TARGET).elf
 
 $(TARGET).elf: $(OBJS)
-	$(CC) -T link.ld -Wl,--nmagic $^ -o $@
+	$(CC) -T link.ld -Wl,--nmagic $^ -o $@ -nostartfiles -specs=nano.specs -specs=nosys.specs
 %.o: %.c
 	$(CC) $(CFLAGS) -MMD -MP -c $< -o $@
 %.o: %.s

--- a/arm9/link.ld
+++ b/arm9/link.ld
@@ -14,5 +14,5 @@ SECTIONS
 
 	. = ALIGN(4);
 
-	__end__ = ABSOLUTE(.);
+	end = ABSOLUTE(.);
 }

--- a/arm9/source/fatfs/sdmmc.c
+++ b/arm9/source/fatfs/sdmmc.c
@@ -29,7 +29,6 @@
 #include <malloc.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <dirent.h>
 #include <errno.h>
 
 #include "sdmmc.h"


### PR DESCRIPTION
$ CC=arm-none-eabi-gcc make

Before:
$ du -h firm_linux_loader.firm
160K    firm_linux_loader.firm

After:
$ du -h firm_linux_loader.firm
56K     firm_linux_loader.firm

Previously we were using devkitARM, previous instructions:
https://github.com/linux-3ds/firm_linux_loader/wiki/Home/_compare/0919c59e42d1490e2e6f67cddc34ab498fc13e96...983d826d3425c878ebafd8e8aa44ed2a46befba2
https://github.com/devkitPro/buildscripts/blob/6a74f8361637781e766bf66ff7cb62be4879f0aa/dkarm-eabi/patches/gcc-10.2.0.patch

Fixes #2
Signed-off-by: Nick Desaulniers <nick.desaulniers@gmail.com>