### PR TITLE
remove some unused defines from linux_config.h

### DIFF
--- a/arm11/source/start.S
+++ b/arm11/source/start.S
@@ -147,7 +147,7 @@ wait_arm9:
 	@ jumping to the kernel entry
 	mov r0, #0
 	ldr r1, =MACHINE_NUMBER
-	ldr r2, =PARAMS_ADDR
+	ldr r2, =DTB_ADDR
 	ldr lr, =ZIMAGE_ADDR
 
 	@ Jump to the kernel!

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[])
 	}
 
 	dtb_filename = is_lgr() ? KTR_DTB_FILENAME : CTR_DTB_FILENAME;
-	if (!load_file(dtb_filename, PARAMS_ADDR)) {
+	if (!load_file(dtb_filename, DTB_ADDR)) {
 		Debug("Failed to load %s", dtb_filename);
 		goto error;
 	}

--- a/common/linux_config.h
+++ b/common/linux_config.h
@@ -1,8 +1,6 @@
 /* Linux settings */
+#define DTB_ADDR         (0x20000000)
 #define ZIMAGE_ADDR      (0x20008000)
-#define ZRELADDR         (0x20008000)
-#define PARAMS_ADDR      (0x20000100)
-#define INITRD_ADDR      (0x20000000)
 #define MACHINE_NUMBER   (0xFFFFFFFF)
 #define ARM9LINUXFW_ADDR (0x08080000)
 #define SYNC_ADDR        (0x1FFFFFF0)


### PR DESCRIPTION
Rename PARAMS_ADDR to DTB_ADDR

Rename PARAMS_ADDR to DTB_ADDR. Move that addr to the previously unused
0x20000000. This gives ~4x the space for the DTBs than their current
size.

Signed-off-by: Nick Desaulniers <nick.desaulniers@gmail.com>