### PR TITLE
fix new3ds clocking when booting from fb3ds/gm9

### DIFF
--- a/arm11/source/smp.c
+++ b/arm11/source/smp.c
@@ -31,7 +31,9 @@ static void wait_cycles(unsigned short cycles)
 
 static void set_clock(short socmode)
 {
-	if (get_pdn_lgr_socmode() == socmode)
+	set_pdn_lgr_socmode(get_pdn_lgr_socmode());
+
+	if ((get_pdn_lgr_socmode() & 7) == socmode)
 		return;
 
 	set_pdn_lgr_socmode(socmode);
@@ -98,7 +100,7 @@ static void online_cores23(void)
 	scu_set_cpu_stat(scu_get_cpu_stat() & 0x0F);
 	downclock();
 	setup_overlays();
-	upclock();
+	// upclock();
 	gic_send_swi(2, 2);
 	gic_send_swi(3, 3);
 }

--- a/arm11/source/smp.c
+++ b/arm11/source/smp.c
@@ -31,6 +31,9 @@ static void wait_cycles(unsigned short cycles)
 
 static void set_clock(short socmode)
 {
+	if (get_pdn_lgr_socmode() == socmode)
+		return;
+
 	set_pdn_lgr_socmode(socmode);
 
 	// Loop until the ACK bit is set.


### PR DESCRIPTION
previously when changing the clock to itself it'd never retrigger the irq and the loader would get stuck in a loop.
now, it just returns when trying to set to the current mode.

since I don't own a new3DS I'll need someone to test it for me.

should fix #23 