### PR TITLE
Add basic initrd support

### DIFF
--- a/arm9/include/fs.h
+++ b/arm9/include/fs.h
@@ -13,6 +13,9 @@ const char* GetWorkDir();
 /** Checks if there is enough space free on the SD card **/
 bool DebugCheckFreeSpace(size_t required);
 
+/** Checks path exists */
+bool FileExists(const char* path);
+
 /** Opens existing files */
 bool FileOpen(const char* path);
 bool DebugFileOpen(const char* path);

--- a/arm9/source/fs.c
+++ b/arm9/source/fs.c
@@ -48,6 +48,14 @@ bool DebugCheckFreeSpace(size_t required)
     return true;
 }
 
+bool FileExists(const char* path)
+{
+	FILINFO fno;
+
+	return f_stat(path, &fno) == FR_OK;
+}
+
+
 bool FileOpen(const char* path)
 {
     unsigned flags = FA_READ | FA_WRITE | FA_OPEN_EXISTING;

--- a/arm9/source/main.c
+++ b/arm9/source/main.c
@@ -74,6 +74,16 @@ int main(int argc, char *argv[])
 		goto error;
 	}
 
+	if (FileExists(INITRAMFS_FILENAME)) {
+		if (!load_file(INITRAMFS_FILENAME, INITRAMFS_ADDR)) {
+			Debug("Failed to load " INITRAMFS_FILENAME);
+			goto error;
+		}
+	}
+	else {
+		Debug("Note: initramfs file not present (" INITRAMFS_FILENAME ")");
+	}
+
 	dtb_filename = is_lgr() ? KTR_DTB_FILENAME : CTR_DTB_FILENAME;
 	if (!load_file(dtb_filename, DTB_ADDR)) {
 		Debug("Failed to load %s", dtb_filename);

--- a/common/linux_config.h
+++ b/common/linux_config.h
@@ -1,11 +1,13 @@
 /* Linux settings */
 #define DTB_ADDR         (0x20000000)
 #define ZIMAGE_ADDR      (0x20008000)
+#define INITRAMFS_ADDR   (0x27800000)
 #define MACHINE_NUMBER   (0xFFFFFFFF)
 #define ARM9LINUXFW_ADDR (0x08080000)
 #define SYNC_ADDR        (0x1FFFFFF0)
 
 #define LINUXIMAGE_FILENAME  "linux/zImage"
+#define INITRAMFS_FILENAME   "linux/initramfs.cpio.gz"
 #define CTR_DTB_FILENAME     "linux/nintendo3ds_ctr.dtb"
 #define KTR_DTB_FILENAME     "linux/nintendo3ds_ktr.dtb"
 #define ARM9LINUXFW_FILENAME "linux/arm9linuxfw.bin"


### PR DESCRIPTION
This adds support for loading the initrd at a specific offset in memory, from a hardcoded file path.

If the path is not present, nothing is done.

* * *

Adding support for amending the FDT structure in-memory to affect `/chosen/bootargs` and `/chosen/linux,initrd*` would be the *correct* way to add proper support for initrd. But a quick `grep` at Linux shows that some platforms do exactly the same, and hardcode the values in the dts files.

As such, this relies on https://github.com/linux-3ds/linux/pull/61